### PR TITLE
Added get_products(rest_url): return products from single request 

### DIFF
--- a/lib/flipkart_api.rb
+++ b/lib/flipkart_api.rb
@@ -22,7 +22,6 @@ class FlipkartApi
     json_data = get_products rest_url
     json_arr << [json_data]
     while json_data["nextUrl"]
-      puts json_data["nextUrl"]
       json_data = get_products json_data["nextUrl"]
       json_arr << [json_data]
     end

--- a/lib/flipkart_api.rb
+++ b/lib/flipkart_api.rb
@@ -18,14 +18,20 @@ class FlipkartApi
   end
   
   def get_all_products(rest_url)
-    rest_output = RestClient.get rest_url, @header
-    all_products = [rest_output]
-    json_data = JSON.parse(rest_output)
+    json_arr = []
+    json_data = get_products rest_url
+    json_arr << [json_data]
     while json_data["nextUrl"]
-      rest_output = RestClient.get json_data["nextUrl"], @header
-      all_products<<[rest_output]
-      json_data = JSON.parse(rest_output)
+      puts json_data["nextUrl"]
+      json_data = get_products json_data["nextUrl"]
+      json_arr << [json_data]
     end
+    jsonout = json_arr.to_json
+  end
+
+  def get_products(rest_url)
+    rest_output = RestClient.get rest_url, @header
+    json_data = JSON.parse(rest_output)
   end
   
   def get_dotd_offers(format)


### PR DESCRIPTION
Added get_products(rest_url): return products from single request 

The flipkart APIs generally takes a long while to return the results and most of times I found it failing. Ability to return single request-response from flipkart_api will help users to save the response and resume downloading next results.
